### PR TITLE
Ajoute des propriétés Open Graph pour les partages

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,17 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <meta name="description" content="Page de présentation de l'évènement Construire l'Être-Machine des Grands Moulin, organisé à l'occasion du festival des idées">
         <meta name="keywords" content="diy,ordinateur,récup,reuse,paris,ateliersconstruire,etre machine">
-        
-		<link href='https://fonts.googleapis.com/css?family=Roboto+Mono:400,400italic,300,300italic,500' rel='stylesheet' type='text/css'>
-		<script src="http://twemoji.maxcdn.com/twemoji.min.js"></script>
+
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="http://grandsmoulins.youandjerrycan.org/" />
+        <meta property="og:locale" content="fr_FR" />
+        <meta property="og:title" content="Construire l'Être-Machine des Grands Moulins" />
+        <meta property="og:description" content="Ateliers créatifs organisés à la Bibliothèque des Grands Moulins à l'occasion du Festival des Idées" />
+        <meta property="og:site_name" content="JerryDIT" />
+        <meta property="og:image" content="http://grandsmoulins.youandjerrycan.org/images/gif0-08.gif" />
+
+        <link href='https://fonts.googleapis.com/css?family=Roboto+Mono:400,400italic,300,300italic,500' rel='stylesheet' type='text/css'>
+        <script src="http://twemoji.maxcdn.com/twemoji.min.js"></script>
 <script src="http://ajax.googleapis.com/ajax/libs/dojo/1.8/dojo/dojo.js"></script>
 <script type="text/javascript">
     require([


### PR DESCRIPTION
Afin d'améliorer la prévisualisation du site lors des partages sur facbook et les réseaux sociaux.
Un débuggeur de ces propriétés existe à cette adresse: https://developers.facebook.com/tools/debug/
